### PR TITLE
feat(ssh-agent-setup): interactive multi-shell support + chezmoi-aware RC patching

### DIFF
--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -149,6 +149,21 @@ init_paths() {
   FINAL_ADD_SERVICE="${SERVICE_DIR}/ssh-add.service"
 }
 
+# shell::init_shell_rc_map <map-var>
+#   Populate an associative array mapping known shells to their RC file paths.
+shell::init_shell_rc_map() {
+  local -n shell_rc_map_ref="${1}"
+
+  shell_rc_map_ref=(
+    [bash]="${HOME}/.bash_profile"
+    [zsh]="${ZDOTDIR:-${HOME}}/.zprofile"
+    [fish]="${XDG_CONFIG_HOME:-${HOME}/.config}/fish/conf.d/ssh_agent.fish"
+    [elvish]="${XDG_CONFIG_HOME}/elvish/rc.elv" # Elvish won't even launch if XDG_CONFIG_HOME is not set
+    # XXX: nu-shell, etc.. could go here
+  )
+}
+}
+
 # Ensure the systemd user directory exists.
 prepare_service_dir() {
   mkdir -p -- "${SERVICE_DIR}" # Avoid race conditions like a smart cookie

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -162,6 +162,17 @@ shell::init_shell_rc_map() {
     # XXX: nu-shell, etc.. could go here
   )
 }
+
+# Helper function to infer the current shell name if the user hasn't explicitly selected one.
+shell::get_current_shell_name() {
+  local shell_name
+
+  shell_name="$(ps -p $$ -o comm=)"
+# Strip path and leading dash to get clean shell name (e.g., 'bash', 'zsh')
+  shell_name="${shell_name#-}"
+  printf "%s\n" "${shell_name##*/}" # Prints the basename
+}
+
 }
 
 # Ensure the systemd user directory exists.

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -195,8 +195,8 @@ patch_shell_rc() {
   shell_name="$(basename "${SHELL:-bash}")"
 
   case "${shell_name}" in
-    bash) rc_file="${HOME}/.bashrc" ;;
-    zsh) rc_file="${HOME}/.zshrc" ;;
+    bash) rc_file="${HOME}/.bash_profile" ;;
+    zsh) rc_file="${HOME}/.zprofile" ;;
     # XXX: this can be easily extended for fish, nu shell, or wtv...
     # IDK how to export vars in those shells though
     # and I don't use them so.

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -72,17 +72,16 @@ source_and_setup_logging() {
   if [[ -f ${logging_path} ]]; then
     # shellcheck source=../../shell/general/logging.shlib
     source "${logging_path}"
-logging::init "$0"
+    logging::init "$0"
   else
     printf "Something went wrong sourcing the logging lib: %s\n" "${logging_path}" >&2
     exit 1
   fi
 }
 
-
 # Show usage details and exit.
 usage() {
-  cat <<GET_YO_KEYS_WET
+  cat << GET_YO_KEYS_WET
 Usage: $(basename "${0}") [key1 [key2...]]
 Options:
 	-h, --help	Show this help message and exit.
@@ -132,7 +131,7 @@ check_dependencies() {
   local deps=(systemctl awk grep ssh-add) # Check grep and awk in case someone manages to run this on a toaster
 
   for cmd in "${deps[@]}"; do
-    if ! command -v "${cmd}" >/dev/null 2>&1; then
+    if ! command -v "${cmd}" > /dev/null 2>&1; then
       logging::log_fatal "Required command '${cmd}' not found."
     fi
   done
@@ -168,7 +167,7 @@ shell::get_current_shell_name() {
   local shell_name
 
   shell_name="$(ps -p $$ -o comm=)"
-# Strip path and leading dash to get clean shell name (e.g., 'bash', 'zsh')
+  # Strip path and leading dash to get clean shell name (e.g., 'bash', 'zsh')
   shell_name="${shell_name#-}"
   printf "%s\n" "${shell_name##*/}" # Prints the basename
 }
@@ -450,7 +449,7 @@ generate_add_service() {
 		}
 		# Leave the other lines alone
 		{ print }
-	' "${TEMPLATE_ADD_SERVICE}" >"${FINAL_ADD_SERVICE}"
+	' "${TEMPLATE_ADD_SERVICE}" > "${FINAL_ADD_SERVICE}"
 
   chmod 600 "${FINAL_ADD_SERVICE}"
   logging::log_info "Created ssh-add.service with keys: \"${keys_ref[*]}\""
@@ -493,7 +492,7 @@ reload_and_start() {
 # 5) reload and start
 main() {
   local -a keys=() # Pass keys around via nameref
-local -A shell_rc_map
+  local -A shell_rc_map
   local -A enabled_shell_rc_map
   local -A selected_shells
   local -A resolved_rc_files_to_patch
@@ -523,6 +522,6 @@ local -A shell_rc_map
 
 # Make sure main is only ran if executed and not
 # if it is sourced.
-if ! (return 0 2>/dev/null); then
+if ! (return 0 2> /dev/null); then
   main "$@"
 fi

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -50,25 +50,29 @@ resolve_file_path() {
     printf "%s\n" "${path}"
   fi
 }
+
+# source_and_setup_logging
 #
 # Resolves this script's directory, builds the path to the logging library
-# (assumed at ../../logging.shlib), and sources it. Exits if missing.
+# (assumed at ../../shell/general/logging.shlib), and sources it. Exits if missing.
 #
 # This loads the namespaced logging functions defined in logging.shlib:
-#   - logging::log_info, logging::log_warn, logging::log_error, logging::log_fatal
-#   - logging::add_err_trap, logging::trap_err_handler
+#   - logging::init logging::log_info, logging::log_warn, logging::log_error,
+#   - logging::log_fatal, logging::add_err_trap, logging::trap_err_handler
+#   - logging::setup_traps logging::add_exit_trap
 #
 # The `logging::` prefix follows the convention described in the
 # Google Shell Style Guide: https://google.github.io/styleguide/shellguide.html
-resolve_and_source_logging() {
+source_and_setup_logging() {
   local script_dir logging_path
 
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  logging_path="$(realpath "${script_dir}/../../logging.shlib")"
+  logging_path="$(resolve_file_path "${script_dir}/../../shell/general/logging.shlib")"
 
   if [[ -f ${logging_path} ]]; then
-    # shellcheck source=../../logging.shlib
+    # shellcheck source=../../shell/general/logging.shlib
     source "${logging_path}"
+logging::init "$0"
   else
     printf "Something went wrong sourcing the logging lib: %s\n" "${logging_path}" >&2
     exit 1


### PR DESCRIPTION
#### 🚀 What’s Changed

- **Interactive multi-shell selection**
  - `shell::init_shell_rc_map()` builds a map of known shells → their login RC files  
  - `shell::get_enabled_shells()` filters against `/etc/shells` and your `$PATH`  
  - `shell::prompt_user_selection()` lets you pick one or more shells (via `fzf` or a numbered fallback)  
  - `shell::print_selected_shells()` logs what will be patched  

- **Multi-shell RC patching**
  - `patch_shell_rc()` now accepts a shell→rc-file map and appends `SSH_AUTH_SOCK` to each  

- **Chezmoi-aware dotfile support**
  - `chezmoi::load_helpers()` + `resolve_all_rc_files()` detect chezmoi-managed RCs and patch the source file instead of the generated symlink  

- **Orchestrated `main()` workflow**
  1. logging setup  
  2. args parsing & dependency checks  
  3. path initialization  
  4. interactive shell selection  
  5. service generation & RC patching  
  6. systemd reload/start  

- **Refactors & Chores**
  - Swapped legacy logging for `logging.shlib` (`source_and_setup_logging()`)  
  - Introduced `resolve_file_path()` to canonicalize symlinks  
  - Applied `shfmt` for consistent indentation, spacing & heredoc alignment  
