### PR TITLE
refactor(ssh-agent-setup): improve robustness, readability, maintainability

### DIFF
--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -489,7 +489,7 @@ generate_add_service() {
   local -r final_add_service="$(path::get_path paths_ref final_add_service)"
 
   # join keys into a newline-separated string for awk
-  keys_concat=$(printf '%s\n' "${keys_ref[@]}")
+  printf -v keys_concat "%s\n" "${keys_ref[@]}"
   ssh_add_bin=$(command -pv ssh-add) || {
     logging::log_fatal "ssh-add not found.. Why are you running an ssh-add script?"
   }

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -145,12 +145,17 @@ parse_args() {
 # Verify required external commands exist.
 check_dependencies() {
   local deps=(systemctl awk grep perl ssh-add) # Check grep and awk in case someone manages to run this on a toaster
+  local -a missing
 
   for cmd in "${deps[@]}"; do
     if ! command -v "${cmd}" > /dev/null 2>&1; then
-      logging::log_fatal "Required command '${cmd}' not found."
+      missing+=("${cmd}")
     fi
   done
+
+  if (( ${#missing[@]} )); then
+    logging::log_fatal "Missing required commands: ${missing[*]}"
+  fi
 }
 
 # Initialize paths for templates and output, store in an associative array

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -144,7 +144,7 @@ parse_args() {
 
 # Verify required external commands exist.
 check_dependencies() {
-  local deps=(systemctl awk grep perl ssh-add) # Check grep and awk in case someone manages to run this on a toaster
+  local -a deps=(systemctl awk grep perl ssh-add) # Check grep and awk in case someone manages to run this on a toaster
   local -a missing
 
   for cmd in "${deps[@]}"; do
@@ -608,7 +608,7 @@ reload_and_start() {
 # 4) generate systemd services & patch RCs
 # 5) reload and start
 main() {
-  local -a keys=() # Pass keys around via nameref
+  local -a keys # Pass keys around via nameref
   local -A paths
   local -A shell_rc_map
   local -A shell_export_map

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -307,7 +307,7 @@ shell::prompt_user_selection() {
     logging::log_info "fzf detected. Launching interactive selector..."
     mapfile -t selections < <(printf "%s\n" "${!enabled_shell_rc_map_ref[@]}" | fzf --multi --prompt="Select shells: ")
   else
-    if ! [[ -t 0 ]]; then
+    if [[ ! -t 0 ]]; then
       logging::log_warn "Non-interactive session detected and fzf is not available."
       logging::log_warn "Skipping shell RC update."
       return 1
@@ -340,7 +340,7 @@ shell::prompt_user_selection() {
     fi
 
     for index in "${indices[@]}"; do
-      if ! [[ ${index} =~ ^[0-9]+$ ]]; then
+      if [[ ! ${index} =~ ^[0-9]+$ ]]; then
         logging::log_warn "Invalid input (not a number): ${index}"
         continue
       fi
@@ -602,7 +602,7 @@ main() {
 
   source_and_setup_logging
 
-  if ! [[ -t 0 ]]; then
+  if [[ ! -t 0 ]]; then
     logging::log_fatal "This script must be run interactively (stdin is not a tty)."
   fi
 

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -310,7 +310,7 @@ shell::prompt_user_selection() {
         case "${confirm_all@L}" in
           y | yes)
             for shell in "${!enabled_shell_rc_map_ref[@]}"; do
-              selected_shells_ref["$shell"]="${enabled_shell_rc_map_ref[$shell]}"
+              selected_shells_ref["${shell}"]="${enabled_shell_rc_map_ref["${shell}"]}"
             done
             ;;
           *)

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -309,10 +309,11 @@ shell::prompt_user_selection() {
   else
     if [[ ! -t 0 ]]; then
       logging::log_warn "Non-interactive session detected and fzf is not available."
-      logging::log_warn "Skipping shell RC update."
+      logging::log_warn "Skipping shell RC update entirely because no interactive input is possible."
       return 1
     fi
 
+    logging::log_info "fzf not found. Falling back to manual read prompt."
     read -rp "Enter the number(s) of the shells to modify (e.g., 1 3): " -a indices
 
     if ((${#indices[@]} == 0)); then

--- a/unix/systemd/ssh-agent-setup.sh
+++ b/unix/systemd/ssh-agent-setup.sh
@@ -581,8 +581,8 @@ BOOM_SHAKALAKA
 
 # Reload user daemon and enable/start services.
 reload_and_start() {
-  systemctl --user daemon-reload
-  systemctl --user enable --now ssh-agent.service ssh-add.service
+  systemctl --user daemon-reload || logging::log_fatal "daemon-reload failed. Check your systemd setup."
+  systemctl --user enable --now ssh-agent.service ssh-add.service || logging::log_fatal "Failed to enable/start ssh-agent.service and/or ssh-add.service."
   logging::log_info "Enabled and started ssh-agent & ssh-add services"
 }
 


### PR DESCRIPTION
## Description

This PR refactors and hardens the `ssh-agent-setup.sh` script by improving error handling, code style consistency, and path management. It also enhances shell RC patching logic to avoid duplicate entries and clarifies logging during interactive prompts. No existing functionality has been removed; rather, this update reorganizes and streamlines the script for better long-term maintenance.

## Changes

- **style:** Declare arrays with `-a` and remove redundant initializations  
  - Use `local -a` for explicit array typing in `check_dependencies` and `main`.  
  - Remove unnecessary initialization of `keys` (no functional change).  

- **style(systemd):** Standardize negation syntax in Bash conditionals  
  - Change all `! [[ … ]]` instances to `[[ ! … ]]` for consistency with Bash idioms.  
  - No functional changes.

- **fix(rc):** Avoid duplicate `SSH_AUTH_SOCK` lines; improve newline handling  
  - Skip appending if the exact export line already exists.  
  - Warn if any other `SSH_AUTH_SOCK` line is present.  
  - Ensure a blank line is added before appending, only if the file does not already end with one.  
  - Improves shell RC patching robustness and reduces risk of duplicate entries.

- **fix(ssh-agent-setup):** Aggregate and report all missing dependencies  
  - Instead of failing on the first missing command, collect all missing dependencies into an array.  
  - Log a single fatal error listing all missing commands (e.g., “Missing required commands: foo bar baz”).  

- **fix(systemd):** Add error handling for `systemctl` commands  
  - Add `|| logging::log_fatal …` after `systemctl --user daemon-reload` and `systemctl --user enable --now …` to ensure failures are logged and surfaced to the user.  
  - Improves robustness when daemon-reloading or enabling/starting services fails.

- **chore(shell):** Clarify logging for manual shell selection prompt  
  - Update log message to specify skipping shell RC update when no interactive input is possible (non-TTY).  
  - Add info log when falling back to manual `read` prompt if `fzf` is not found.  

- **refactor(systemd):** Use `printf -v` for direct assignment to `keys_concat`  
  - Replace a subshell-based assignment with `printf -v` to avoid spawning an extra process.  
  - No functional change.

- **refactor(systemd):** Encapsulate path management in an associative array  
  - Introduce `path::init_paths` to initialize a `paths` associative array containing all template and output file locations.  
  - Provide a helper `path::get_path` to retrieve values by key, with fatal logging if a key is missing.  
  - Update `prepare_service_dir`, `link_agent`, and `generate_add_service` to accept and use the `paths` array.  
  - Refactor `main` to call `path::init_paths paths`, then pass `paths` to all path-dependent functions.  
  - Eliminates global variables for file paths and improves readability.

- **refactor:** Add braces for associative array keys in `shell::prompt_user_selection`  
  - Surround both LHS and RHS of associative array references with braces:  
    ```bash
    selected_shells_ref["${shell}"]="${enabled_shell_rc_map_ref["${shell}"]}"
    ```
  - Satisfies ShellCheck SC2250; no functional change.

- **fix(systemd):** Make `shell::get_enabled_shells` more robust and readable  
  - Refactor the `mapfile` call to remove the `A && B || C` idiom, replacing it with explicit `if …; then …; fi`.  
  - Distinguish between a `mapfile` failure (I/O or syntax error) versus an empty result set.  
  - Log a fatal error if `/etc/shells` is unreadable or yields no valid shells.

  ## Related Commits

- [`733df9f`](https://…/commit/733df9fb9d4497318b4e2342f536374d1c0a5284) — style: declare arrays with `-a` flag and remove redundant initialization  
- [`806b8c7`](https://…/commit/806b8c731182a3fb036de308d12ae884665b4341) — fix(rc): avoid duplicate SSH_AUTH_SOCK lines, improve newline handling  
- [`bf6046a`](https://…/commit/bf6046a567e7e5344d8302c46ef772e797d23879) — fix(ssh-agent-setup): aggregate and report all missing dependencies  
- [`976d0f7`](https://…/commit/976d0f7bdc5b6664555914692655fea1124f0e8e) — fix(systemd): add error handling for systemctl commands  
- [`114dc04`](https://…/commit/114dc04545eae1aa9e46a3b74be6f1a9f8f78d07) — chore(shell): clarify logging for manual shell selection prompt  
- [`0751a5f`](https://…/commit/0751a5f1e931c36020202da7eb8159fb30f63795) — style(systemd): standardize negation syntax in bash conditionals  
- [`978a1be`](https://…/commit/978a1bef6b40577b093e325b17d8835e6c043aa8) — refactor(systemd): use printf -v for direct assignment to keys_concat  
- [`9ad5e3c`](https://…/commit/9ad5e3c39c86da2cea2fa29ca1dd1184eb158157) — refactor(systemd): encapsulate path management in associative array  
- [`205fb4a`](https://…/commit/205fb4a883d78a119b6677f447393d97d6b26c82) — refactor: add braces for associative array keys in shell selection  
- [`6d28001`](https://…/commit/6d280018d3e4c1d0b9d18092e76f0a2102e2a0c5) — fix(systemd): make get_enabled_shells more robust and readable
